### PR TITLE
refactor(Client): remove port parameter from Client constructor. not …

### DIFF
--- a/includes/server/Client.hpp
+++ b/includes/server/Client.hpp
@@ -6,7 +6,7 @@
 /*   By: pmelo-ca <pmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/07 19:21:28 by codespace         #+#    #+#             */
-/*   Updated: 2025/07/29 09:21:18 by pmelo-ca         ###   ########.fr       */
+/*   Updated: 2025/08/16 13:45:48 by pmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,6 @@ class Client {
   private:
     int            _fd;
     int            _id;
-    uint16_t       _port;
     bool           _isAuthenticated;
     std::string     _password;
     std::string     _nickName;
@@ -38,7 +37,7 @@ class Client {
     bool            _hasValidUser;
 
   public:
-    Client(int fd, int id, uint16_t port, std::string ipAddress);
+    Client(int fd, int id, std::string ipAddress);
     ~Client();
 
     // Getters

--- a/sources/server/Client.cpp
+++ b/sources/server/Client.cpp
@@ -6,15 +6,15 @@
 /*   By: pmelo-ca <pmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/07 19:21:48 by codespace         #+#    #+#             */
-/*   Updated: 2025/07/28 12:07:03 by pmelo-ca         ###   ########.fr       */
+/*   Updated: 2025/08/16 13:47:15 by pmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../includes/server/Client.hpp"
 #include "../includes/utils/Colors.hpp"
 
-Client::Client(int fd, int id, uint16_t port, std::string ipAddress)
- : _fd(fd), _id(id), _port(port), _isAuthenticated(false), _ipAddress(ipAddress),
+Client::Client(int fd, int id, std::string ipAddress)
+ : _fd(fd), _id(id), _isAuthenticated(false), _ipAddress(ipAddress),
   _hasValidPass(false), _hasValidNick(false), _hasValidUser(false) {}
 
 Client::~Client() {}

--- a/sources/server/Server.cpp
+++ b/sources/server/Server.cpp
@@ -6,7 +6,7 @@
 /*   By: pmelo-ca <pmelo-ca@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/29 10:34:31 by pmelo-ca          #+#    #+#             */
-/*   Updated: 2025/08/01 12:34:16 by pmelo-ca         ###   ########.fr       */
+/*   Updated: 2025/08/16 13:47:52 by pmelo-ca         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -158,10 +158,9 @@ void Server::handleNewClient() {
     client_event.events = EPOLLIN | EPOLLET;
     client_event.data.fd = conn_socket;
     std::string clientIp = inet_ntoa(client_addr.sin_addr);
-    uint16_t clientPort = ntohs(client_addr.sin_port);
 
     std::cout << GREEN << "Client connected. " << "fd: " << conn_socket <<  RESET << std::endl;
-    _clientsVector.push_back(Client(conn_socket, getServerIdCounter(), clientPort, clientIp));
+    _clientsVector.push_back(Client(conn_socket, getServerIdCounter(), clientIp));
     setServerIdCounter(getServerIdCounter() + 1);
 
     if (epoll_ctl(getEpollFd(), EPOLL_CTL_ADD, conn_socket, &client_event) < 0) {


### PR DESCRIPTION
…needed.
This pull request refactors the `Client` class to remove the storage and handling of the client's port number. The constructor and internal state no longer track the port, simplifying the class interface and its usage throughout the codebase.

**Refactoring and interface simplification:**

* Removed the `_port` member variable from the `Client` class, so the client’s port is no longer stored as part of the client’s state. (`includes/server/Client.hpp` [includes/server/Client.hppL25](diffhunk://#diff-47a5d94172fb7753db4b4d4f18f4e7c6cf125787ba5ffc5af92201aea5a6bd34L25))
* Updated the `Client` constructor to remove the `port` parameter, both in the class declaration and definition. (`includes/server/Client.hpp` [[1]](diffhunk://#diff-47a5d94172fb7753db4b4d4f18f4e7c6cf125787ba5ffc5af92201aea5a6bd34L41-R40) `sources/server/Client.cpp` [[2]](diffhunk://#diff-8b27959a101a8b0878017a43d09d003b3ebe6fcd23afe5b1f6e165f7f117844aL9-R17)
* Updated the instantiation of `Client` objects in `Server::handleNewClient` to no longer pass the port argument. (`sources/server/Server.cpp` [sources/server/Server.cppL161-R163](diffhunk://#diff-85176593e90928b0ed88d5c96d544667f91025bf2e4f0248e5d4d581c966ede3L161-R163))

**General maintenance:**

* Updated file headers to reflect the latest modification dates. (`includes/server/Client.hpp` [[1]](diffhunk://#diff-47a5d94172fb7753db4b4d4f18f4e7c6cf125787ba5ffc5af92201aea5a6bd34L9-R9) `sources/server/Client.cpp` [[2]](diffhunk://#diff-8b27959a101a8b0878017a43d09d003b3ebe6fcd23afe5b1f6e165f7f117844aL9-R17) `sources/server/Server.cpp` [[3]](diffhunk://#diff-85176593e90928b0ed88d5c96d544667f91025bf2e4f0248e5d4d581c966ede3L9-R9)